### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 
 		<dependency.ats.commons.version>0.2.9</dependency.ats.commons.version>
 		<dependency.aws.version>1.8.10.2</dependency.aws.version>
-		<dependency.commons-collection.version>3.2.1</dependency.commons-collection.version>
+		<dependency.commons-collection.version>3.2.2</dependency.commons-collection.version>
 		<dependency.commons.io.version>2.4</dependency.commons.io.version>
 		<dependency.commons-lang.version>2.6</dependency.commons-lang.version>
 		<dependency.commons-log.version>1.1.3</dependency.commons-log.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
